### PR TITLE
Removed React 15.5 warnings

### DIFF
--- a/lib/react-loader.js
+++ b/lib/react-loader.js
@@ -1,42 +1,42 @@
 (function (root, factory) {
 
   if (typeof define === 'function' && define.amd) {
-    define(['react', 'react-dom', 'spin.js'], factory);
+    define(['react', 'react-dom', 'spin.js', 'prop-types', 'create-react-class'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = factory(require('react'), require('react-dom'), require('spin.js'));
+    module.exports = factory(require('react'), require('react-dom'), require('spin.js'), require('prop-types'), require('create-react-class'));
   } else {
-    root.Loader = factory(root.React, root.ReactDOM, root.Spinner);
+    root.Loader = factory(root.React, root.ReactDOM, root.Spinner, root.PropTypes, root.createReactClass);
   }
 
-}(this, function (React, ReactDOM, Spinner) {
+}(this, function (React, ReactDOM, Spinner, PropTypes, createReactClass) {
 
-  var Loader = React.createClass({displayName: "Loader",
+  var Loader = createReactClass({
     propTypes: {
-      className:       React.PropTypes.string,
-      color:           React.PropTypes.string,
-      component:       React.PropTypes.any,
-      corners:         React.PropTypes.number,
-      direction:       React.PropTypes.oneOf([1, -1]),
-      fps:             React.PropTypes.number,
-      hwaccell:        React.PropTypes.bool,
-      left:            React.PropTypes.string,
-      length:          React.PropTypes.number,
-      lines:           React.PropTypes.number,
-      loaded:          React.PropTypes.bool,
-      loadedClassName: React.PropTypes.string,
-      opacity:         React.PropTypes.number,
-      options:         React.PropTypes.object,
-      parentClassName: React.PropTypes.string,
-      position:        React.PropTypes.string,
-      radius:          React.PropTypes.number,
-      rotate:          React.PropTypes.number,
-      scale:           React.PropTypes.number,
-      shadow:          React.PropTypes.bool,
-      speed:           React.PropTypes.number,
-      top:             React.PropTypes.string,
-      trail:           React.PropTypes.number,
-      width:           React.PropTypes.number,
-      zIndex:          React.PropTypes.number
+      className:       PropTypes.string,
+      color:           PropTypes.string,
+      component:       PropTypes.any,
+      corners:         PropTypes.number,
+      direction:       PropTypes.oneOf([1, -1]),
+      fps:             PropTypes.number,
+      hwaccell:        PropTypes.bool,
+      left:            PropTypes.string,
+      length:          PropTypes.number,
+      lines:           PropTypes.number,
+      loaded:          PropTypes.bool,
+      loadedClassName: PropTypes.string,
+      opacity:         PropTypes.number,
+      options:         PropTypes.object,
+      parentClassName: PropTypes.string,
+      position:        PropTypes.string,
+      radius:          PropTypes.number,
+      rotate:          PropTypes.number,
+      scale:           PropTypes.number,
+      shadow:          PropTypes.bool,
+      speed:           PropTypes.number,
+      top:             PropTypes.string,
+      trail:           PropTypes.number,
+      width:           PropTypes.number,
+      zIndex:          PropTypes.number
     },
 
     getDefaultProps: function () {

--- a/lib/react-loader.jsx
+++ b/lib/react-loader.jsx
@@ -1,42 +1,44 @@
 (function (root, factory) {
 
   if (typeof define === 'function' && define.amd) {
-    define(['react', 'react-dom', 'spin.js'], factory);
+    define(['react', 'react-dom', 'spin.js', 'prop-types', 'create-react-class'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = factory(require('react'), require('react-dom'), require('spin.js'));
+    module.exports = factory(require('react'), require('react-dom'), require('spin.js'),
+        require('prop-types'), require('create-react-class'));
   } else {
-    root.Loader = factory(root.React, root.ReactDOM, root.Spinner);
+    root.Loader = factory(root.React, root.ReactDOM, root.Spinner, root.PropTypes,
+        root.createReactClass);
   }
 
-}(this, function (React, ReactDOM, Spinner) {
+}(this, function (React, ReactDOM, Spinner, PropTypes, createReactClass) {
 
-  var Loader = React.createClass({
+  var Loader = createReactClass({
     propTypes: {
-      className:       React.PropTypes.string,
-      color:           React.PropTypes.string,
-      component:       React.PropTypes.any,
-      corners:         React.PropTypes.number,
-      direction:       React.PropTypes.oneOf([1, -1]),
-      fps:             React.PropTypes.number,
-      hwaccell:        React.PropTypes.bool,
-      left:            React.PropTypes.string,
-      length:          React.PropTypes.number,
-      lines:           React.PropTypes.number,
-      loaded:          React.PropTypes.bool,
-      loadedClassName: React.PropTypes.string,
-      opacity:         React.PropTypes.number,
-      options:         React.PropTypes.object,
-      parentClassName: React.PropTypes.string,
-      position:        React.PropTypes.string,
-      radius:          React.PropTypes.number,
-      rotate:          React.PropTypes.number,
-      scale:           React.PropTypes.number,
-      shadow:          React.PropTypes.bool,
-      speed:           React.PropTypes.number,
-      top:             React.PropTypes.string,
-      trail:           React.PropTypes.number,
-      width:           React.PropTypes.number,
-      zIndex:          React.PropTypes.number
+      className:       PropTypes.string,
+      color:           PropTypes.string,
+      component:       PropTypes.any,
+      corners:         PropTypes.number,
+      direction:       PropTypes.oneOf([1, -1]),
+      fps:             PropTypes.number,
+      hwaccell:        PropTypes.bool,
+      left:            PropTypes.string,
+      length:          PropTypes.number,
+      lines:           PropTypes.number,
+      loaded:          PropTypes.bool,
+      loadedClassName: PropTypes.string,
+      opacity:         PropTypes.number,
+      options:         PropTypes.object,
+      parentClassName: PropTypes.string,
+      position:        PropTypes.string,
+      radius:          PropTypes.number,
+      rotate:          PropTypes.number,
+      scale:           PropTypes.number,
+      shadow:          PropTypes.bool,
+      speed:           PropTypes.number,
+      top:             PropTypes.string,
+      trail:           PropTypes.number,
+      width:           PropTypes.number,
+      zIndex:          PropTypes.number
     },
 
     getDefaultProps: function () {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "react-dom": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
+    "create-react-class": "^15.5.2",
+    "prop-types": "^15.5.8",
     "spin.js": "2.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Added `prop-types`, `create-react-class` package dependencies, updated component to use prop-types lib instead of `React.PropType` and create-react-class instead of `React.createClass`

Here is more info about warnings https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes