### PR TITLE
Accept all minor versions of React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/quickleft/react-loader",
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0 || ~16.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0 || ~16.0.0"
+    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "create-react-class": "^15.5.2",


### PR DESCRIPTION
Accept React versions for 16.X.X, not only 16.0.X

Documentation reference:
https://docs.npmjs.com/getting-started/semantic-versioning
