### PR TITLE
Update react-loader.jsx

### DIFF
--- a/lib/react-loader.jsx
+++ b/lib/react-loader.jsx
@@ -57,7 +57,7 @@
       this.updateState(this.props);
     },
 
-    componentWillReceiveProps: function (nextProps) {
+    UNSAFE_componentWillReceiveProps: function (nextProps) {
       this.updateState(nextProps);
     },
 


### PR DESCRIPTION
componentWillReceiveProps is no longer supported from react v16.3 .
Replacing it with UNSAFE_componentWillReceiveProps

#### What does this PR do?
This will replace the componentWillReceiveProps which is no longer supported from react v16.3

#### Where should the reviewer start?

#### How should this be manually tested?
I have tested it by manually putting the lines in my code. 
#### Any background context you want to provide?
No .
#### What are the relevant issues (if any)?
Updating to new react version will throw the error or warning about componentWillReceiveProps component.  
#### Screenshots (if appropriate)

#### Obligatory GIF
