### PR TITLE
 componentWillReceiveProps renamed as it is no longer supported in react

### DIFF
--- a/lib/react-loader.js
+++ b/lib/react-loader.js
@@ -57,7 +57,7 @@
       this.updateState(this.props);
     },
 
-    componentWillReceiveProps: function (nextProps) {
+    UNSAFE_componentWillReceiveProps: function (nextProps) {
       this.updateState(nextProps);
     },
 

--- a/lib/react-loader.jsx
+++ b/lib/react-loader.jsx
@@ -57,7 +57,7 @@
       this.updateState(this.props);
     },
 
-    componentWillReceiveProps: function (nextProps) {
+    UNSAFE_componentWillReceiveProps: function (nextProps) {
       this.updateState(nextProps);
     },
 

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "spin.js": "2.x"
   },
   "devDependencies": {
-    "browserify": "^5.9.1",
+    "browserify": "^16.5.0",
     "chai": "^1.9.1",
     "es6-shim": "0.35.3",
-    "mocha": "^2.4.5",
+    "mocha": "^7.0.1",
     "mocha-phantomjs": "^4.0.2",
     "react": "^15.0.0",
     "react-dom": "^15.0.0",


### PR DESCRIPTION
componentWillReceiveProps is no longer supported from react v16.3 .
Replacing it with UNSAFE_componentWillReceiveProps
Also replaced the .js file. 
Updated composer.json file to the latest versions of packages which previously contains vulnerabilities . 

What does this PR do?
This will replace the componentWillReceiveProps which is no longer supported from react v16.3

Where should the reviewer start?
How should this be manually tested?
I have tested it by manually putting the lines in my code.

Any background context you want to provide?
No .

What are the relevant issues (if any)?
Updating to new react version will throw the error or warning about componentWillReceiveProps component.

Screenshots (if appropriate)
Obligatory GIF